### PR TITLE
Fix "class not found" error and typo

### DIFF
--- a/Civi/Inlay/FormProcessor.php
+++ b/Civi/Inlay/FormProcessor.php
@@ -55,7 +55,7 @@ class FormProcessor extends InlayType {
     $fp = civicrm_api3('FormProcessorInstance', 'get', ['sequential' => 1, 'name' => $this->config['formProcessor']])['values'][0] ?? NULL;
     if (!$fp) {
       // aaaagh!
-      throw new RuntimeException("Cannot load form processor '{$this->config['formProcessor']}'");
+      throw new \RuntimeException("Cannot load form processor '{$this->config['formProcessor']}'");
     }
 
     // Parse the layout.

--- a/ang/inlayfp/InlayFP.html
+++ b/ang/inlayfp/InlayFP.html
@@ -21,7 +21,7 @@
         />
     </div>
 
-    <div crm-ui-field="{name: 'inlayForm.formProcessor', title: ts('Form Procesor name')}">
+    <div crm-ui-field="{name: 'inlayForm.formProcessor', title: ts('Form Processor name')}">
       <select
         crm-ui-select="{allowClear:false, dropdownAutoWidth: true}"
         ng-model="inlay.config.formProcessor"


### PR DESCRIPTION
Hi Rich,

These are both fairly self-explanatory and trivial so I feel OK sending both of these in the same PR.

As you might guess, I haven't got very far yet.  There's a fairly obvious bug (the `config.name` is `string:myformname` instead of `1` or `myformname`) but I'm going to brush up on my Angular before tackling that, since it seems the problem is in how the select input is generated.